### PR TITLE
 fix:max_value check

### DIFF
--- a/.github/workflows/test_run_ci.yml
+++ b/.github/workflows/test_run_ci.yml
@@ -147,8 +147,8 @@ jobs:
 
           sudo apt-get install -y jq
           max_value=$(jq -r '.["'"${{ matrix.client }}"'"].GasLimit.max' "results-$DATE/reports/result.json")
-          if [ "$max_value" = "0" ] || [ -z "$max_value" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0 or missing)."
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
             exit 1
           else
             echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
@@ -222,9 +222,18 @@ jobs:
           python3 report_metadata.py "$DATE" speed
 
           sudo apt-get install -y jq
-          max_value=$(jq -r '.speed["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/speed/reports/speed.json")
-          if [ "$max_value" = "0" ] || [ -z "$max_value" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0 or missing)."
+          echo "check  first run speed max_value"
+          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/speed/reports/speed.json")
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
+            exit 1
+          else
+            echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
+          fi
+          echo "check  second run speed max_value"
+          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].second.max'  "results-$DATE/speed/reports/speed.json")
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
             exit 1
           else
             echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
@@ -298,17 +307,19 @@ jobs:
           python3 report_metadata.py "$DATE" memory
 
           sudo apt-get install -y jq
-          max_value=$(jq -r '.memory["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/memory/reports/memory.json")
-          if [ "$max_value" = "0" ] || [ -z "$max_value" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0 or missing)."
+          echo "check  first run memory max_value"
+          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/memory/reports/memory.json")
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
             exit 1
           else
             echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
           fi
 
-          max_value=$(jq -r '.memory["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].second.max'  "results-$DATE/memory/reports/memory.json")
-          if [ "$max_value" = "0" ] || [ -z "$max_value" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0 or missing)."
+          echo "check  second run memory max_value"
+          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].second.max'  "results-$DATE/memory/reports/memory.json")
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
             exit 1
           else
             echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
@@ -383,8 +394,8 @@ jobs:
 
           sudo apt-get install -y jq
           max_value=$(jq -r '.["'"${{ matrix.client }}"'"].GasLimit.max' "results-$DATE/reports/result.json")
-          if [ "$max_value" = "0" ] || [ -z "$max_value" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0 or missing)."
+          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
             exit 1
           else
             echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."

--- a/.github/workflows/test_run_ci.yml
+++ b/.github/workflows/test_run_ci.yml
@@ -222,22 +222,22 @@ jobs:
           python3 report_metadata.py "$DATE" speed
 
           sudo apt-get install -y jq
-          echo "check  first run speed max_value"
-          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/speed/reports/speed.json")
-          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
-            exit 1
-          else
-            echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
-          fi
-          echo "check  second run speed max_value"
-          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].second.max'  "results-$DATE/speed/reports/speed.json")
-          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
-            exit 1
-          else
-            echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
-          fi
+
+          for run in first second; do
+            echo "Debug - Checking $run run speed for Client: $CLIENT Size: ${SIZE}M Date: $DATE"
+            echo "jq path: .\"$CLIENT\".\"${SIZE}M\".$run.max"
+            max_value=$(jq -r \
+              --arg client "$CLIENT" \
+              --arg size "${SIZE}M" \
+              --arg run "$run" \
+              '.[$client][$size][$run].max' "results-$DATE/speed/reports/speed.json")
+            if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+              echo "Client '$CLIENT' has no valid data in $run run (max=0,-1 or missing)."
+              exit 1
+            else
+              echo "Client '$CLIENT' has valid data in $run run (max=$max_value)."
+            fi
+          done
 
       - name: Zip the results folder
         run: |
@@ -307,23 +307,21 @@ jobs:
           python3 report_metadata.py "$DATE" memory
 
           sudo apt-get install -y jq
-          echo "check  first run memory max_value"
-          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].first.max'  "results-$DATE/memory/reports/memory.json")
-          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
-            exit 1
-          else
-            echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
-          fi
 
-          echo "check  second run memory max_value"
-          max_value=$(jq -r '.["'"${{ matrix.client }}"'"]["'"${{ matrix.size }}"'"].second.max'  "results-$DATE/memory/reports/memory.json")
-          if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
-            echo "Client '${{ matrix.client }}' has no valid data (max=0,-1 or missing)."
-            exit 1
-          else
-            echo "Client '${{ matrix.client }}' has valid data (max=$max_value)."
-          fi
+          for run in first second; do
+            echo "Check $run run memory max_value"
+            max_value=$(jq -r \
+              --arg client "$CLIENT" \
+              --arg size "${SIZE}M" \
+              --arg run "$run" \
+              '.[$client][$size][$run].max' "results-$DATE/memory/reports/memory.json")
+            if [ "$max_value" = "0" ] || [ "$max_value" = "-1" ] || [ "$max_value" = "null" ]; then
+              echo "Client '$CLIENT' has no valid data in $run run (max=0, -1 or missing)."
+              exit 1
+            else
+              echo "Client '$CLIENT' has valid data in $run run (max=$max_value)."
+            fi
+          done
 
       - name: Zip the results folder
         run: |

--- a/images.yaml
+++ b/images.yaml
@@ -1,6 +1,6 @@
 images:
   nethermind: "nethermind/nethermind:1.30.3"
-  geth: "ethereum/client-go:v1.14.12"
+  geth: "ethereum/client-go:v1.15.0"
   reth: "ghcr.io/paradigmxyz/reth:v1.1.5"
   erigon: "erigontech/erigon:v2.61.0"
   besu: "hyperledger/besu:25.1.0"


### PR DESCRIPTION
1. jq get max_value's path is wrong, should not include `memory` or `speed` prefix
wrong: `jq '.speed.geth["1000M"].first' results-20250201/speed/reports/speed.json`
right: `jq '.geth["1000M"].first' results-20250201/speed/reports/speed.json`
eg.
```
root@Ubuntu-2204-jammy-amd64-base ~/benchmarks/genesis-init-benchmarks # jq '.speed.geth["1000M"].first' results-20250201/speed/reports/speed.json
null

root@Ubuntu-2204-jammy-amd64-base ~/benchmarks/genesis-init-benchmarks # jq '.geth["1000M"].first' results-20250201/speed/reports/speed.json{
  "max": 280684,
  "p50": 279069,
  "p95": 280496,
  "p99": 280646,
  "min": 278044,
  "count": 8
}
```
2.when jq returns null, it's actually the string "null", not an empty string. That's why the check [ -z "$max_value" ] doesn't catch it because "null" isn't empty.

So previous workflow results were incorrect, the max value is not correct (because of the first point above); 
secondly, the judgment logic is incorrect.
https://github.com/OpenFusionist/benchmarks-data-results/actions/runs/13192813202/job/36835502366
![image](https://github.com/user-attachments/assets/fa2adcc3-a5ea-4456-8d07-77f19a37d4e9)

